### PR TITLE
Add 16kb page size support in native build

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -12,6 +12,12 @@ android {
         minSdk = 24
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        externalNativeBuild {
+          cmake {
+            arguments += listOf("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
+          }
+        }
     }
 
     externalNativeBuild {


### PR DESCRIPTION
From https://developer.android.com/guide/practices/page-sizes#compile-r27