### PR TITLE
Optimise build flags

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         externalNativeBuild {
           cmake {
             arguments += listOf("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
+              targets("session_util")
           }
         }
     }
@@ -39,6 +40,12 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+
+            externalNativeBuild {
+                cmake {
+                    arguments += listOf("-DCMAKE_BUILD_TYPE=Release")
+                }
+            }
         }
 
         debug {


### PR DESCRIPTION
...so that
1. `Release` is build instead of `RelWithDebugInfo`
2. Only `session_util` target is built, no other shared libraries sneaked in